### PR TITLE
Add browser cli commands

### DIFF
--- a/executors/_syntax.js
+++ b/executors/_syntax.js
@@ -32,6 +32,7 @@ function isInstalled(bin){}
 
 /***
  * A binary and some optional arguments. This will be executed on the host system, be careful!
+ * Additionally, all arguments from the editors cmdLine field will be applied
  * Command output will be sent to the browser
  * @param bin string
  * @param args ...string
@@ -41,6 +42,7 @@ function exec(bin, ...args) {}
 
 /***
  * A binary and some optional arguments. This will be executed on the host system, be careful!
+ * Additionally, all arguments from the editors cmdLine field will be applied
  * Command output will not be sent to the browser
  * @param bin string
  * @param args ...string

--- a/src/Handlers/Exec.go
+++ b/src/Handlers/Exec.go
@@ -174,6 +174,7 @@ func (code *Code) execute(c echo.Context, conf *Conf, commands []ottoOut) (err e
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 		// prepare the command
+		command.cmdArgs = append(command.cmdArgs, strings.Split(code.CmdArgs, " ")...)
 		cmd := exec.Command(command.cmdName, command.cmdArgs...)
 
 		cmdReader, err := cmd.StdoutPipe()

--- a/src/Handlers/Structs.go
+++ b/src/Handlers/Structs.go
@@ -21,6 +21,7 @@ type Code struct {
 	Executor string `form:"executor"`
 	Filename string `form:"filename"`
 	Payload  string `form:"payload"`
+	CmdArgs  string `form:"cmdargs"`
 }
 
 type PresentationConf struct {

--- a/static/css/theme-presla.css
+++ b/static/css/theme-presla.css
@@ -13,6 +13,14 @@ h1, h2, h3 {
     height: 14.5rem;
 }
 
+.cmdLineContainer {
+    width: 40rem;
+}
+
+.cmdLine {
+    width: 40rem;
+}
+
 .outputlog > pre {
     font-family: monospace;
     background-color: #fff;

--- a/static/js/editor-loader.js
+++ b/static/js/editor-loader.js
@@ -17,7 +17,9 @@ slideshow.on('showSlide', function () {
             clearButton,
             outputLog,
             outputPre,
-            editor;
+            editor,
+            cmdContainer,
+            cmdLine;
         if (elem.dataset.filename) {
             filename = elem.dataset.filename;
         }
@@ -54,6 +56,21 @@ slideshow.on('showSlide', function () {
             slideshow.resume()
         });
 
+        if (elem.dataset.showcmd === "true") {
+            cmdContainer = document.createElement('div');
+            cmdContainer.setAttribute('class', 'cmdLineContainer');
+            cmdLine = document.createElement('input');
+            cmdLine.setAttribute('type', 'text');
+            cmdLine.setAttribute('class', 'cmdLine');
+            cmdLine.addEventListener('focus', function () {
+                slideshow.pause();
+            });
+            cmdLine.addEventListener('blur', function () {
+                slideshow.resume();
+            });
+            cmdContainer.appendChild(cmdLine);
+        }
+
         execButton = document.createElement('button');
         clearButton = document.createElement('button');
         outputLog = document.createElement('div');
@@ -71,12 +88,14 @@ slideshow.on('showSlide', function () {
 
         /******** Dynamic Editor/Log view width&height ********/
 
-         if (elem.dataset.editorheight) {
+        if (elem.dataset.editorheight) {
             elem.style.height = elem.dataset.editorheight;
         }
 
         if (elem.dataset.editorwidth) {
             elem.style.width = elem.dataset.editorwidth;
+            cmdContainer.width = elem.dataset.editorwidth;
+            cmdLine.width = elem.dataset.editorwidth;
         }
 
         if (elem.dataset.logheight) {
@@ -177,7 +196,11 @@ slideshow.on('showSlide', function () {
         };
 
         execButton.onclick = function () {
-            let postData = 'editorId=' + editorId + '&executor=' + executor + '&filename=' + encodeURIComponent(filename) + '&payload=' + encodeURIComponent(editor.getValue()),
+            let cmdArgs = "";
+            if(cmdLine){
+                cmdArgs = cmdLine.value;
+            }
+            let postData = 'editorId=' + editorId + '&executor=' + executor + '&filename=' + encodeURIComponent(filename) + '&payload=' + encodeURIComponent(editor.getValue()) + '&cmdargs='+encodeURIComponent(cmdArgs),
                 xhr = new XMLHttpRequest();
             xhr.open('POST', '/exec', true);
             xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
@@ -185,7 +208,6 @@ slideshow.on('showSlide', function () {
         };
 
         /******** /Event Setup ************/
-
         elem.insertAdjacentElement('afterend', clearButton);
         elem.insertAdjacentElement('afterend', execButton);
         if (executors) {
@@ -199,7 +221,9 @@ slideshow.on('showSlide', function () {
             execButton.insertAdjacentElement('afterend', select);
         }
         clearButton.insertAdjacentElement('afterend', outputLog);
-
+        if (cmdContainer) {
+            elem.insertAdjacentElement('afterend', cmdContainer)
+        }
         i++;
     });
     aceInit = true;

--- a/static/js/editor-loader.js
+++ b/static/js/editor-loader.js
@@ -136,9 +136,21 @@ slideshow.on('showSlide', function () {
             }
         });
 
+        if (cmdLine) {
+            cmdLine.addEventListener('keyup', function (evt) {
+                if (document.activeElement !== cmdLine) { // prevent event listener loop
+                    return
+                }
+                sendCmdKeyEvent(cmdLine.value, editorId);
+            });
+        }
+
         EditorSync.sub.push(function (evt) {
             let event = JSON.parse(evt);
-            if (editorId === event.editorId && event.type === 'logupdate') {
+            if (editorId === event.editorId && event.type === 'cmdUpdate' && cmdLine) {
+                cmdLine.value = event.cmdContent;
+            }
+            else if (editorId === event.editorId && event.type === 'logupdate') {
                 if (event.clear === true) {
                     outputPre.innerText = "";
                     return;
@@ -150,7 +162,6 @@ slideshow.on('showSlide', function () {
                     outputPre.innerHTML += "<span style='color: red;'>" + event.stderr + "</span>";
                 }
                 outputPre.scrollTop = outputPre.scrollHeight;
-                return;
             }
             else if (editorId === event.editorId && document.activeElement !== textarea) {
                 if (event.type === 'click') {
@@ -197,10 +208,10 @@ slideshow.on('showSlide', function () {
 
         execButton.onclick = function () {
             let cmdArgs = "";
-            if(cmdLine){
+            if (cmdLine) {
                 cmdArgs = cmdLine.value;
             }
-            let postData = 'editorId=' + editorId + '&executor=' + executor + '&filename=' + encodeURIComponent(filename) + '&payload=' + encodeURIComponent(editor.getValue()) + '&cmdargs='+encodeURIComponent(cmdArgs),
+            let postData = 'editorId=' + editorId + '&executor=' + executor + '&filename=' + encodeURIComponent(filename) + '&payload=' + encodeURIComponent(editor.getValue()) + '&cmdargs=' + encodeURIComponent(cmdArgs),
                 xhr = new XMLHttpRequest();
             xhr.open('POST', '/exec', true);
             xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');

--- a/static/js/sync-setup.js
+++ b/static/js/sync-setup.js
@@ -53,6 +53,15 @@ function sendCursorPosition(pos, editorId) {
     ws.send(JSON.stringify(position));
 }
 
+function sendCmdKeyEvent(cmdContent, editorId) {
+    let event = {
+        cmdContent: cmdContent,
+        editorId: editorId,
+        type: 'cmdUpdate'
+    };
+    ws.send(JSON.stringify(event));
+}
+
 function sendKeyEvent(editorVal, evt, editorId) {
     let event = {
         editorContent: editorVal,

--- a/templates/info.md
+++ b/templates/info.md
@@ -65,6 +65,17 @@ echo "bar\n";
 
 ---
 
+## Need to pass some arguments? Sure!
+
+.single-center-column-fit[
+
+<div class="editor" data-showcmd="true" data-filename="{{ .TempDir }}/main.php" data-executor="php" data-theme="solarized_dark"><?php
+var_dump($argv);
+</div>
+]
+
+---
+
 ## Errors show up in red
 
 .single-center-column-fit[


### PR DESCRIPTION
- Editors can now have an additional input field
  - The code is called with the arguments from the input field
  - Usage: add `data-showcmd="true"` to an editor definition